### PR TITLE
Update Retry.php

### DIFF
--- a/src/Actions/Retry.php
+++ b/src/Actions/Retry.php
@@ -28,9 +28,8 @@ class Retry extends Action
     public function handle(ActionFields $fields, Collection $models): void
     {
         foreach ($models as $model) {
-            Artisan::call('queue:retry', [
-                'id' => $model->id,
-            ]);
+            $uuid = $model->uuid;
+            Artisan::call("queue:retry $uuid");
         }
     }
 }


### PR DESCRIPTION
hi mate, I tried this retry function on laravel 8.5 and it doesn't seem to work. it seems to me they use uuid instead of ID

php artisan queue:failed

return a table with Id = uuid

+--------------------------------------+------------+---------+-------------------------------------+---------------------+
| ID                                   | Connection | Queue   | Class                               | Failed At           |
+--------------------------------------+------------+---------+-------------------------------------+---------------------+
| b07ed27a-15b1-4a8c-afe6-a12c7e3102ea | database   | default | App\Jobs\MyJob| 2021-07-30 11:33:14 |
+--------------------------------------+------------+---------+-------------------------------------+---------------------+

I've tested this fix and it works on my end :)