### PR TITLE
Add German translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 composer.phar
 phpunit.xml
+.idea

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -1,0 +1,19 @@
+{
+	"Name": "Name",
+	"Connection": "Verbindung",
+	"Exception": "Exception",
+	"Queue": "Queue",
+	"Queues": "Queues",
+	"Attempts": "Versuche",
+	"Delay": "Verzögerung",
+	"Payload": "Payload",
+	"Reserved At": "Reserviert am",
+	"Available At": "Verfügbar am",
+	"Created At": "Erstellt am",
+	"Failed At": "Fehlgeschlagen am",
+	"Job": "Job",
+	"Jobs": "Jobs",
+	"Failed Job": "Fehlgeschlagener Job",
+	"Failed Jobs": "Fehlgeschlagene Jobs",
+	"Retry": "Wiederholen"
+}

--- a/resources/lang/de/validation.php
+++ b/resources/lang/de/validation.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+
+	'attributes' => [
+		'connection' => 'Verbindung',
+		'exception' => 'Exception',
+		'queue' => 'Queue',
+		"attempts" => "Versuche",
+		'payload' => 'Payload',
+		'reserved_at' => 'Reserviert am',
+		'available_at' => 'Verfügbar ab',
+		'failed_at' => 'Fehlgeschlagen am',
+	],
+
+];


### PR DESCRIPTION
I just installed this package and added the german translation locally so I thought it would be nice to open a pull request.

As you may see, some terms are still in English. The reason is that we just don't have good words for this in german or it's not expected to use them in this context. For this reason the following terms are still in English:

- Exception
- Queue
- Queues
- Payload

And Job is a word that exists like this in German and means the same.