### PR TITLE
Adds options to the config to enable/disable the creation of Jobs in Laravel Nova

### DIFF
--- a/config/nova-queues.php
+++ b/config/nova-queues.php
@@ -35,4 +35,9 @@ return [
 
     'navigation-group' => 'Queues',
 
+    'can_create' => [
+        'job' => false,
+        'failed_job' => false,
+    ],
+
 ];

--- a/src/Models/FailedJob.php
+++ b/src/Models/FailedJob.php
@@ -72,10 +72,10 @@ class FailedJob extends \Illuminate\Database\Eloquent\Model
      * Allow the creation of new failed jobs within Laravel Nova
      *
      * @param Request $request
-     * @return mixed
+     * @return bool
      */
-    public static function authorizedToCreate(Request $request)
-    {
+    public static function authorizedToCreate(Request $request): bool
+	{
         return config('nova-queues.can_create.failed_job', false);
     }
 }

--- a/src/Models/FailedJob.php
+++ b/src/Models/FailedJob.php
@@ -67,4 +67,15 @@ class FailedJob extends \Illuminate\Database\Eloquent\Model
     {
         return $this->payload['delay'];
     }
+
+    /**
+     * Allow the creation of new failed jobs within Laravel Nova
+     *
+     * @param Request $request
+     * @return mixed
+     */
+    public static function authorizedToCreate(Request $request)
+    {
+        return config('nova-queues.can_create.failed_job', false);
+    }
 }

--- a/src/Models/Job.php
+++ b/src/Models/Job.php
@@ -2,6 +2,8 @@
 
 namespace Den1n\NovaQueues\Models;
 
+use Illuminate\Http\Request;
+
 class Job extends \Illuminate\Database\Eloquent\Model
 {
     protected $guarded = [
@@ -64,5 +66,16 @@ class Job extends \Illuminate\Database\Eloquent\Model
     public function getDelayAttribute(): int
     {
         return $this->payload['delay'] ?? 0;
+    }
+
+    /**
+     * Allow the creation of new jobs within Laravel Nova
+     *
+     * @param Request $request
+     * @return mixed
+     */
+    public static function authorizedToCreate(Request $request)
+    {
+        return config('nova-queues.can_create.job', false);
     }
 }

--- a/src/Models/Job.php
+++ b/src/Models/Job.php
@@ -72,9 +72,9 @@ class Job extends \Illuminate\Database\Eloquent\Model
      * Allow the creation of new jobs within Laravel Nova
      *
      * @param Request $request
-     * @return mixed
+     * @return bool
      */
-    public static function authorizedToCreate(Request $request)
+    public static function authorizedToCreate(Request $request): bool
     {
         return config('nova-queues.can_create.job', false);
     }


### PR DESCRIPTION
That's something that is inspired by Issue #4 

I just don't find it very elegant to extend the two resources in that way. After publishing the vendor files I have access to the config so I thought it would be nice to change the setting there.

I set the defaults to false because I think it's really an edge case that you want to add an job inside of Nova itself.