### PR TITLE
Adds a new config option to overwrite the need for an user permission to create jobs

### DIFF
--- a/config/nova-queues.php
+++ b/config/nova-queues.php
@@ -35,6 +35,16 @@ return [
 
     'navigation-group' => 'Queues',
 
+    /**
+     * Overwrites the need of an action permission to retry a failed job.
+     */
+
+    'overwrite_action_permission' => false,
+
+    /**
+     * Allows or disallows the creation of new jobs and failed jobs within Laravel Nova.
+     */
+
     'can_create' => [
         'job' => false,
         'failed_job' => false,

--- a/src/Resources/FailedJob.php
+++ b/src/Resources/FailedJob.php
@@ -154,8 +154,8 @@ class FailedJob extends Resource
     {
         return [
             (new \Den1n\NovaQueues\Actions\Retry)->canRun(function ($request, $job) {
-                return $request->user()->can('create', $job);
-            }),
+                return config('nova-queues.overwrite_action_permission', false) || $request->user()->can('create', $job);
+            })->showOnTableRow(),
         ];
     }
 


### PR DESCRIPTION
Sorry for the amount of PRs. I just like the package and notice little things that could be a optimized from my perspective. If it's too much just let me know and I create a personalized fork for myself.

Anyways enough of the disclaimer. What is this PR about?
I use my Nova installation completely alone and will never add people to it that aren't allowed to do the exact same things than me. So I don't like the need to create an extra permission to create jobs just for the retry action. 

For this reason I added another option to the config to overwrite/bypass the need of the permission. Per default it's false because I think you should know when to retry an job and for most people it's probably reasonable to have a permission for this task in their project.

I additionally enabled that the option is directly in the option menu on the index table row.