### PR TITLE
Changes the function to export the language files

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -32,7 +32,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         ], 'config');
 
         $this->publishes([
-            __DIR__ . '/../resources/lang' => resource_path('lang/vendor/nova-queues'),
+            __DIR__ . '/../resources/lang' => lang_path('vendor/nova-queues'),
         ], 'lang');
     }
 


### PR DESCRIPTION
`resource_path('lang/…')` is no longer needed and error-prone because of the change of the language path in Laravel 9.

I just realized, that none of my translations work anymore on PHP level (took a while to realize this because most of my frontend is translated via Vue.js). After a bit research I saw that the export of the language files is done with `resource_path('lang/vendor/nova-queues')` which puts the files in `/resources/lang` instead of `/lang`. Until Laravel 8 this was not a problem but the language directory changed in Laravel 9. But if there is an `lang` directory in `resources` the one in the main directory is ignored.

So I optimized the export to use the new `lang_path()` function.